### PR TITLE
feat: calculate velocity boost for AB / MWD correctly

### DIFF
--- a/.storybook/fits.ts
+++ b/.storybook/fits.ts
@@ -84,8 +84,7 @@ export const fullFit = {
       {
         "flag": 21,
         "quantity": 1,
-        "type_id": 2281,
-        "state": "Active"
+        "type_id": 2281
       },
       {
         "flag": 22,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Patric Stout <eveshipfit@truebrain.nl>",
   "license": "MIT",
   "dependencies": {
-    "@eveshipfit/dogma-engine": "^2.0.1",
+    "@eveshipfit/dogma-engine": "^2.1.0",
     "clsx": "^2.0.0"
   },
   "devDependencies": {

--- a/src/DogmaEngineProvider/DogmaEngineProvider.tsx
+++ b/src/DogmaEngineProvider/DogmaEngineProvider.tsx
@@ -43,6 +43,11 @@ export interface DogmaEngineProps {
  *   console.log(stats);
  * }
  * ```
+ *
+ * Due to how the EVE SDE is constructed, a skill is by default
+ * assumed to be Level 1. This means that you most likely want
+ * to give all the skills to the calculate() function, even those
+ * that are not trained.
  */
 export const DogmaEngineProvider = (props: DogmaEngineProps) => {
   const [dogmaEngine, setDogmaEngine] = React.useState<DogmaEngine>({});

--- a/src/EveDataProvider/EveDataProvider.tsx
+++ b/src/EveDataProvider/EveDataProvider.tsx
@@ -7,7 +7,7 @@ import { DogmaAttribute, DogmaEffect, TypeDogma, TypeID } from "./DataTypes";
 // eslint-disable-next-line import/extensions
 import * as esf_pb2 from "./esf_pb2.js";
 
-const defaultDataUrl = "https://data.eveship.fit/20231023-3/";
+const defaultDataUrl = "https://data.eveship.fit/20231023-4/";
 
 interface DogmaData {
   loaded?: boolean;


### PR DESCRIPTION
For this the dataset is modified to add effects and modifier. Additionally, some bugs in dogma-engine resulted in wrong numbers, so we bump that while at it.