### PR TITLE
fix: datafiles don't load when content-encoding is used

### DIFF
--- a/src/EveDataProvider/EveDataProvider.tsx
+++ b/src/EveDataProvider/EveDataProvider.tsx
@@ -29,9 +29,8 @@ export interface DogmaDataProps {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function fetchDataFile(dataUrl: string, name: string, pb2: any): Promise<object[]> {
   const response = await fetch(dataUrl + name + ".pb2");
-  const contentLength = response.headers.get("content-length");
   const reader = response.body?.getReader();
-  const result = await pb2.decode(reader, contentLength);
+  const result = await pb2.decode(reader, 0xffffffff);
 
   return result.entries;
 }

--- a/src/EveDataProvider/esf_pb2.js
+++ b/src/EveDataProvider/esf_pb2.js
@@ -29,6 +29,7 @@ export const esf = $root.esf = (() => {
                 if (r.need_data()) {
                     await r.fetch_data();
                 }
+                if (r.is_eof()) break;
 
                 var t = r.uint32();
                 switch (t >>> 3) {
@@ -214,6 +215,7 @@ export const esf = $root.esf = (() => {
                 if (r.need_data()) {
                     await r.fetch_data();
                 }
+                if (r.is_eof()) break;
 
                 var t = r.uint32();
                 switch (t >>> 3) {
@@ -352,6 +354,7 @@ export const esf = $root.esf = (() => {
                 if (r.need_data()) {
                     await r.fetch_data();
                 }
+                if (r.is_eof()) break;
 
                 var t = r.uint32();
                 switch (t >>> 3) {
@@ -472,6 +475,7 @@ export const esf = $root.esf = (() => {
                 if (r.need_data()) {
                     await r.fetch_data();
                 }
+                if (r.is_eof()) break;
 
                 var t = r.uint32();
                 switch (t >>> 3) {

--- a/src/EveDataProvider/protobuf.js
+++ b/src/EveDataProvider/protobuf.js
@@ -23,6 +23,7 @@ function Reader(reader) {
     this._buf = new Uint8Array();
     this._next_buf = null;
     this._buf_pos = 0;
+    this._eof = false;
 
     this.pos = 0;
     this.len = 0;
@@ -57,6 +58,7 @@ Reader.prototype.fetch_data = async function fetch_data() {
     /* If we read nothing, fast-path into an end-of-file marker. */
     if (length === 0) {
         this._next_buf = new Uint8Array();
+        this._eof = true;
         return;
     }
 
@@ -73,6 +75,10 @@ Reader.prototype.fetch_data = async function fetch_data() {
         this._next_buf.set(value, pos);
         pos += value.length;
     }
+}
+
+Reader.prototype.is_eof = function is_eof() {
+    return this._eof && this._buf_pos >= this._buf.length;
 }
 
 Reader.prototype.read = function read(len) {


### PR DESCRIPTION
content-length is not set by Cloudflare when content-encoding is used. So no longer depend on content-length, and just read till the end of the file.