### PR TITLE
fix: ShipAttribute storybook uses invalid attribute-name

### DIFF
--- a/src/ShipAttribute/ShipAttribute.stories.tsx
+++ b/src/ShipAttribute/ShipAttribute.stories.tsx
@@ -31,7 +31,7 @@ const withShipSnapshotProvider: Decorator<{name: string}> = (Story, context) => 
 
 export const Default: Story = {
   args: {
-    name: "cpuUsage",
+    name: "cpuUsed",
   },
   decorators: [withShipSnapshotProvider],
   parameters: {


### PR DESCRIPTION
The name changed a while ago from cpuUsage to cpuUsed.