### PR TITLE
fix: unable to toggle modules

### DIFF
--- a/src/ShipFit/ShipFit.module.css
+++ b/src/ShipFit/ShipFit.module.css
@@ -121,5 +121,5 @@
     position: absolute;
     top: 0;
     width: 100%;
-    z-index: 100;
+    z-index: 3;
 }


### PR DESCRIPTION
The new "share-link" had a z-index that was too high, making it capture all the clicks.