### PR TITLE
chore(storybook): Disable telemetry

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,9 @@ const config: StorybookConfig = {
   docs: {
     autodocs: "tag",
   },
+  core: {
+    disableTelemetry: true,
+  },
   webpackFinal: async (config: any) => {
     return {
       ...config,


### PR DESCRIPTION
This also applies `prettier` formatting on the file, as it seemed to disagree with some lines.

Note: as per [documentation](https://storybook.js.org/docs/configure/telemetry), there is one `boot` event that is sent before this config it set. The alternative is to force the `STORYBOOK_DISABLE_TELEMETRY` env var, but that seems a bit much.