### PR TITLE
refactor: move skills storage inside ShipSnapshotProvider

### DIFF
--- a/src/CalculationDetail/CalculationDetail.stories.tsx
+++ b/src/CalculationDetail/CalculationDetail.stories.tsx
@@ -21,17 +21,15 @@ type Story = StoryObj<typeof CalculationDetail>;
 const useShipSnapshotProvider: Decorator<{
   source: "Ship" | "Char" | "Structure" | "Target" | { Item?: number; Cargo?: number };
 }> = (Story, context) => {
-  const [skills, setSkills] = React.useState<Record<string, number>>({});
-
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={setSkills}>
-        <DogmaEngineProvider>
-          <ShipSnapshotProvider {...context.parameters.snapshot} skills={skills}>
+      <DogmaEngineProvider>
+        <ShipSnapshotProvider {...context.parameters.snapshot}>
+          <EsiProvider>
             <Story {...context.args} />
-          </ShipSnapshotProvider>
-        </DogmaEngineProvider>
-      </EsiProvider>
+          </EsiProvider>
+        </ShipSnapshotProvider>
+      </DogmaEngineProvider>
     </EveDataProvider>
   );
 };
@@ -43,7 +41,7 @@ export const Default: Story = {
   decorators: [useShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
+      initialFit: fullFit,
     },
   },
 };

--- a/src/DroneBay/DroneBay.stories.tsx
+++ b/src/DroneBay/DroneBay.stories.tsx
@@ -19,19 +19,17 @@ export default meta;
 type Story = StoryObj<typeof DroneBay>;
 
 const useShipSnapshotProvider: Decorator<Record<string, never>> = (Story, context) => {
-  const [skills, setSkills] = React.useState<Record<string, number>>({});
-
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={setSkills}>
-        <DogmaEngineProvider>
-          <ShipSnapshotProvider {...context.parameters.snapshot} skills={skills}>
+      <DogmaEngineProvider>
+        <ShipSnapshotProvider {...context.parameters.snapshot}>
+          <EsiProvider>
             <div style={{ width: context.args.width, height: context.args.width }}>
               <Story />
             </div>
-          </ShipSnapshotProvider>
-        </DogmaEngineProvider>
-      </EsiProvider>
+          </EsiProvider>
+        </ShipSnapshotProvider>
+      </DogmaEngineProvider>
     </EveDataProvider>
   );
 };

--- a/src/EsiCharacterSelection/EsiCharacterSelection.stories.tsx
+++ b/src/EsiCharacterSelection/EsiCharacterSelection.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof EsiCharacterSelection>;
 const withEsiProvider: Decorator<Record<string, never>> = (Story) => {
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={console.log}>
+      <EsiProvider>
         <Story />
       </EsiProvider>
     </EveDataProvider>

--- a/src/EsiProvider/EsiProvider.stories.tsx
+++ b/src/EsiProvider/EsiProvider.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
+import { fullFit } from "../../.storybook/fits";
+
 import { EsiContext, EsiProvider } from "./";
 import { EveDataProvider } from "../EveDataProvider";
+import { ShipSnapshotProvider } from "../ShipSnapshotProvider";
 
 const meta: Meta<typeof EsiProvider> = {
   component: EsiProvider,
@@ -35,16 +38,13 @@ const TestEsi = () => {
 };
 
 export const Default: Story = {
-  args: {
-    setSkills: (skills: Record<string, number>) => {
-      console.log(skills);
-    },
-  },
-  render: (args) => (
+  render: () => (
     <EveDataProvider>
-      <EsiProvider {...args}>
-        <TestEsi />
-      </EsiProvider>
+      <ShipSnapshotProvider initialFit={fullFit}>
+        <EsiProvider>
+          <TestEsi />
+        </EsiProvider>
+      </ShipSnapshotProvider>
     </EveDataProvider>
   ),
 };

--- a/src/EsiProvider/EsiProvider.tsx
+++ b/src/EsiProvider/EsiProvider.tsx
@@ -1,7 +1,7 @@
 import { jwtDecode } from "jwt-decode";
 import React from "react";
 
-import { EsiFit } from "../ShipSnapshotProvider";
+import { EsiFit, ShipSnapshotContext } from "../ShipSnapshotProvider";
 
 import { getAccessToken } from "./EsiAccessToken";
 import { getSkills } from "./EsiSkills";
@@ -47,8 +47,6 @@ export const EsiContext = React.createContext<Esi>({
 });
 
 export interface EsiProps {
-  /** Callback to call when skills are changed. */
-  setSkills: (skills: Record<string, number>) => void;
   /** Children that can use this provider. */
   children: React.ReactNode;
 }
@@ -58,6 +56,7 @@ export interface EsiProps {
  */
 export const EsiProvider = (props: EsiProps) => {
   const eveData = React.useContext(EveDataContext);
+  const snapshot = React.useContext(ShipSnapshotContext);
 
   const [esi, setEsi] = React.useState<Esi>({
     loaded: undefined,
@@ -151,7 +150,7 @@ export const EsiProvider = (props: EsiProps) => {
     /* Skills already fetched? We won't do it again till the user reloads. */
     const currentSkills = esi.characters[characterId]?.skills;
     if (currentSkills !== undefined) {
-      props.setSkills(currentSkills);
+      snapshot.changeSkills(currentSkills);
       return;
     }
 
@@ -178,7 +177,7 @@ export const EsiProvider = (props: EsiProps) => {
         };
       });
 
-      props.setSkills(skills);
+      snapshot.changeSkills(skills);
       return;
     }
 
@@ -208,7 +207,7 @@ export const EsiProvider = (props: EsiProps) => {
           };
         });
 
-        props.setSkills(skills);
+        snapshot.changeSkills(skills);
       });
 
       getCharFittings(characterId, accessToken).then((charFittings) => {

--- a/src/EveShipFitLink/EveShipFitLink.stories.tsx
+++ b/src/EveShipFitLink/EveShipFitLink.stories.tsx
@@ -34,8 +34,7 @@ export const Default: Story = {
   decorators: [withShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };

--- a/src/EveShipFitLink/EveShipFitLink.tsx
+++ b/src/EveShipFitLink/EveShipFitLink.tsx
@@ -39,16 +39,16 @@ export function useEveShipFitLink() {
     if (!shipSnapshot?.loaded) return;
 
     async function doCreateLink() {
-      if (!shipSnapshot?.fit) {
+      if (!shipSnapshot?.currentFit) {
         setFitLink("");
         return;
       }
 
-      const fitHash = await encodeEsiFit(shipSnapshot.fit);
+      const fitHash = await encodeEsiFit(shipSnapshot.currentFit);
       setFitLink(`https://eveship.fit/#fit:${fitHash}`);
     }
     doCreateLink();
-  }, [shipSnapshot?.loaded, shipSnapshot?.fit]);
+  }, [shipSnapshot?.loaded, shipSnapshot?.currentFit]);
 
   return fitLink;
 }

--- a/src/FitButtonBar/FitButtonBar.stories.tsx
+++ b/src/FitButtonBar/FitButtonBar.stories.tsx
@@ -41,8 +41,7 @@ export const Default: Story = {
   decorators: [withEveDataProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };

--- a/src/FitButtonBar/RenameButton.tsx
+++ b/src/FitButtonBar/RenameButton.tsx
@@ -18,7 +18,7 @@ export const RenameButton = () => {
   }, [rename, shipSnapshot]);
 
   const openRename = React.useCallback(() => {
-    setRename(shipSnapshot?.fit?.name ?? "");
+    setRename(shipSnapshot?.currentFit?.name ?? "");
     setIsRenameOpen(true);
   }, [shipSnapshot]);
 

--- a/src/FitButtonBar/SaveButton.tsx
+++ b/src/FitButtonBar/SaveButton.tsx
@@ -17,13 +17,13 @@ export const SaveButton = () => {
   const saveBrowser = React.useCallback(
     (force?: boolean) => {
       if (!localFit.loaded) return;
-      if (!shipSnapshot.loaded || !shipSnapshot?.fit) return;
+      if (!shipSnapshot.loaded || !shipSnapshot?.currentFit) return;
 
       setIsPopupOpen(false);
 
       if (!force) {
         for (const fit of localFit.fittings) {
-          if (fit.name === shipSnapshot.fit.name) {
+          if (fit.name === shipSnapshot.currentFit.name) {
             setIsAlreadyExistsOpen(true);
             return;
           }
@@ -32,7 +32,7 @@ export const SaveButton = () => {
 
       setIsAlreadyExistsOpen(false);
 
-      localFit.addFit(shipSnapshot.fit);
+      localFit.addFit(shipSnapshot.currentFit);
     },
     [localFit, shipSnapshot],
   );
@@ -61,7 +61,7 @@ export const SaveButton = () => {
         title="Update Fitting?"
       >
         <div>
-          <div>You have a fitting with the name {shipSnapshot?.fit?.name}, do you want to update it?</div>
+          <div>You have a fitting with the name {shipSnapshot?.currentFit?.name}, do you want to update it?</div>
           <div className={styles.alreadyExistsButtons}>
             <span className={clsx(styles.button, styles.buttonSmall)} onClick={() => saveBrowser(true)}>
               Yes

--- a/src/FormatAsEft/FormatAsEft.stories.tsx
+++ b/src/FormatAsEft/FormatAsEft.stories.tsx
@@ -33,8 +33,7 @@ export const Default: Story = {
   decorators: [withEveDataProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };

--- a/src/FormatAsEft/FormatAsEft.tsx
+++ b/src/FormatAsEft/FormatAsEft.tsx
@@ -30,14 +30,14 @@ export function useFormatAsEft() {
 
   return (): string | undefined => {
     if (!eveData?.loaded) return undefined;
-    if (!shipSnapshot?.loaded || shipSnapshot.fit == undefined) return undefined;
+    if (!shipSnapshot?.loaded || shipSnapshot.currentFit == undefined) return undefined;
 
     let eft = "";
 
-    const shipType = eveData.typeIDs?.[shipSnapshot.fit.ship_type_id];
+    const shipType = eveData.typeIDs?.[shipSnapshot.currentFit.ship_type_id];
     if (!shipType) return undefined;
 
-    eft += `[${shipType.name}, ${shipSnapshot.fit.name}]\n`;
+    eft += `[${shipType.name}, ${shipSnapshot.currentFit.name}]\n`;
 
     for (const slotType of Object.keys(esiFlagMapping) as ShipSnapshotSlotsType[]) {
       let index = 1;
@@ -46,7 +46,7 @@ export function useFormatAsEft() {
         if (index > shipSnapshot.slots[slotType]) break;
         index += 1;
 
-        const module = shipSnapshot.fit.items.find((item) => item.flag === flag);
+        const module = shipSnapshot.currentFit.items.find((item) => item.flag === flag);
         if (module === undefined) {
           eft += "[Empty " + slotToEft[slotType] + "]\n";
           continue;

--- a/src/HardwareListing/HardwareListing.stories.tsx
+++ b/src/HardwareListing/HardwareListing.stories.tsx
@@ -19,19 +19,17 @@ export default meta;
 type Story = StoryObj<typeof HardwareListing>;
 
 const useShipSnapshotProvider: Decorator<Record<string, never>> = (Story, context) => {
-  const [skills, setSkills] = React.useState<Record<string, number>>({});
-
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={setSkills}>
-        <DogmaEngineProvider>
-          <ShipSnapshotProvider {...context.parameters.snapshot} skills={skills}>
+      <DogmaEngineProvider>
+        <ShipSnapshotProvider {...context.parameters.snapshot}>
+          <EsiProvider>
             <div style={{ width: context.args.width, height: context.args.width }}>
               <Story />
             </div>
-          </ShipSnapshotProvider>
-        </DogmaEngineProvider>
-      </EsiProvider>
+          </EsiProvider>
+        </ShipSnapshotProvider>
+      </DogmaEngineProvider>
     </EveDataProvider>
   );
 };
@@ -40,7 +38,7 @@ export const Default: Story = {
   decorators: [useShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
+      initialFit: fullFit,
     },
   },
 };

--- a/src/HullListing/HullListing.stories.tsx
+++ b/src/HullListing/HullListing.stories.tsx
@@ -22,17 +22,17 @@ type Story = StoryObj<typeof HullListing>;
 const withEsiProvider: Decorator<Record<string, never>> = (Story, context) => {
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={console.log}>
-        <LocalFitProvider>
-          <DogmaEngineProvider>
-            <ShipSnapshotProvider {...context.parameters.snapshot}>
+      <DogmaEngineProvider>
+        <ShipSnapshotProvider {...context.parameters.snapshot}>
+          <LocalFitProvider>
+            <EsiProvider>
               <div style={{ height: "400px" }}>
                 <Story />
               </div>
-            </ShipSnapshotProvider>
-          </DogmaEngineProvider>
-        </LocalFitProvider>
-      </EsiProvider>
+            </EsiProvider>
+          </LocalFitProvider>
+        </ShipSnapshotProvider>
+      </DogmaEngineProvider>
     </EveDataProvider>
   );
 };
@@ -42,8 +42,7 @@ export const Default: Story = {
   decorators: [withEsiProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };

--- a/src/HullListing/HullListing.tsx
+++ b/src/HullListing/HullListing.tsx
@@ -222,7 +222,7 @@ export const HullListing = () => {
       if (hull.marketGroupID === undefined) continue;
       if (!hull.published) continue;
 
-      if (filter.currentHull && shipSnapShot.fit?.ship_type_id !== parseInt(typeId)) continue;
+      if (filter.currentHull && shipSnapShot.currentFit?.ship_type_id !== parseInt(typeId)) continue;
 
       const fits: ListingFit[] = [];
       if (anyFilter) {
@@ -231,7 +231,7 @@ export const HullListing = () => {
         if (filter.esiCharacter && Object.keys(esiCharacterFits).includes(typeId))
           fits.push(...esiCharacterFits[typeId]);
         if (fits.length == 0) {
-          if (!filter.currentHull || shipSnapShot.fit?.ship_type_id !== parseInt(typeId)) continue;
+          if (!filter.currentHull || shipSnapShot.currentFit?.ship_type_id !== parseInt(typeId)) continue;
         }
       } else {
         if (Object.keys(localCharacterFits).includes(typeId)) fits.push(...localCharacterFits[typeId]);
@@ -257,7 +257,7 @@ export const HullListing = () => {
     }
 
     setHullGroups(newHullGroups);
-  }, [eveData, search, filter, localCharacterFits, esiCharacterFits, shipSnapShot.fit?.ship_type_id]);
+  }, [eveData, search, filter, localCharacterFits, esiCharacterFits, shipSnapShot.currentFit?.ship_type_id]);
 
   return (
     <div className={styles.listing}>

--- a/src/ShipAttribute/ShipAttribute.stories.tsx
+++ b/src/ShipAttribute/ShipAttribute.stories.tsx
@@ -36,8 +36,7 @@ export const Default: Story = {
   decorators: [withShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };

--- a/src/ShipFit/Hull.tsx
+++ b/src/ShipFit/Hull.tsx
@@ -11,7 +11,7 @@ export interface ShipFitProps {
 export const Hull = () => {
   const shipSnapshot = React.useContext(ShipSnapshotContext);
 
-  const hull = shipSnapshot?.fit?.ship_type_id;
+  const hull = shipSnapshot?.currentFit?.ship_type_id;
   if (hull === undefined) {
     return <></>;
   }

--- a/src/ShipFit/ShipFit.stories.tsx
+++ b/src/ShipFit/ShipFit.stories.tsx
@@ -38,8 +38,7 @@ export const Default: Story = {
   decorators: [withShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };

--- a/src/ShipFitExtended/ShipFitExtended.stories.tsx
+++ b/src/ShipFitExtended/ShipFitExtended.stories.tsx
@@ -19,19 +19,17 @@ export default meta;
 type Story = StoryObj<typeof ShipFitExtended>;
 
 const useShipSnapshotProvider: Decorator<Record<string, never>> = (Story, context) => {
-  const [skills, setSkills] = React.useState<Record<string, number>>({});
-
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={setSkills}>
-        <DogmaEngineProvider>
-          <ShipSnapshotProvider {...context.parameters.snapshot} skills={skills}>
+      <DogmaEngineProvider>
+        <ShipSnapshotProvider {...context.parameters.snapshot}>
+          <EsiProvider>
             <div style={{ width: context.args.width, height: context.args.width }}>
               <Story />
             </div>
-          </ShipSnapshotProvider>
-        </DogmaEngineProvider>
-      </EsiProvider>
+          </EsiProvider>
+        </ShipSnapshotProvider>
+      </DogmaEngineProvider>
     </EveDataProvider>
   );
 };
@@ -43,7 +41,7 @@ export const Default: Story = {
   decorators: [useShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
+      initialFit: fullFit,
     },
   },
 };

--- a/src/ShipFitExtended/ShipFitExtended.tsx
+++ b/src/ShipFitExtended/ShipFitExtended.tsx
@@ -74,7 +74,7 @@ const FitName = () => {
   return (
     <>
       <div className={styles.fitNameTitle}>Name</div>
-      <div className={styles.fitNameContent}>{shipSnapshot?.fit?.name}</div>
+      <div className={styles.fitNameContent}>{shipSnapshot?.currentFit?.name}</div>
     </>
   );
 };

--- a/src/ShipSnapshotProvider/ShipSnapshotProvider.stories.tsx
+++ b/src/ShipSnapshotProvider/ShipSnapshotProvider.stories.tsx
@@ -49,8 +49,7 @@ const TestShipSnapshot = () => {
 
 export const Default: Story = {
   args: {
-    fit: fullFit,
-    skills: {},
+    initialFit: fullFit,
   },
   render: (args) => (
     <EveDataProvider>

--- a/src/ShipStatistics/ShipStatistics.stories.tsx
+++ b/src/ShipStatistics/ShipStatistics.stories.tsx
@@ -19,17 +19,15 @@ export default meta;
 type Story = StoryObj<typeof ShipStatistics>;
 
 const useShipSnapshotProvider: Decorator<Record<string, never>> = (Story, context) => {
-  const [skills, setSkills] = React.useState<Record<string, number>>({});
-
   return (
     <EveDataProvider>
-      <EsiProvider setSkills={setSkills}>
-        <DogmaEngineProvider>
-          <ShipSnapshotProvider {...context.parameters.snapshot} skills={skills}>
+      <DogmaEngineProvider>
+        <ShipSnapshotProvider {...context.parameters.snapshot}>
+          <EsiProvider>
             <Story />
-          </ShipSnapshotProvider>
-        </DogmaEngineProvider>
-      </EsiProvider>
+          </EsiProvider>
+        </ShipSnapshotProvider>
+      </DogmaEngineProvider>
     </EveDataProvider>
   );
 };
@@ -38,7 +36,7 @@ export const Default: Story = {
   decorators: [useShipSnapshotProvider],
   parameters: {
     snapshot: {
-      fit: fullFit,
+      initialFit: fullFit,
     },
   },
 };

--- a/src/TreeListing/TreeListing.stories.tsx
+++ b/src/TreeListing/TreeListing.stories.tsx
@@ -22,8 +22,7 @@ export const Default: Story = {
   },
   parameters: {
     snapshot: {
-      fit: fullFit,
-      skills: {},
+      initialFit: fullFit,
     },
   },
 };


### PR DESCRIPTION
This makes EsiProvider dependant on ShipSnapshotProvider, but also avoids pages having to store skills themselves.

This is an alternative to #80.
Closes #80.