### PR TITLE
fix: round statistics up/down correctly

### DIFF
--- a/src/ShipAttribute/ShipAttribute.tsx
+++ b/src/ShipAttribute/ShipAttribute.tsx
@@ -12,6 +12,8 @@ export interface AttributeProps {
   isResistance?: boolean;
   /** With what value, if any, to divide the attribute value. */
   divideBy?: number;
+  /** Whether to forcefully round down. */
+  roundDown?: boolean;
 }
 
 /**
@@ -29,7 +31,6 @@ export function useAttribute(type: "Ship" | "Char", props: AttributeProps) {
     } else {
       value = shipSnapshot.char?.attributes.get(attributeId)?.value;
     }
-    let highIsGood = eveData.dogmaAttributes?.[attributeId]?.highIsGood;
 
     if (value == undefined) {
       return "?";
@@ -37,7 +38,6 @@ export function useAttribute(type: "Ship" | "Char", props: AttributeProps) {
 
     if (props.isResistance) {
       value = 100 - value * 100;
-      highIsGood = !highIsGood;
     }
 
     if (props.divideBy) {
@@ -46,12 +46,13 @@ export function useAttribute(type: "Ship" | "Char", props: AttributeProps) {
 
     const k = Math.pow(10, props.fixed);
     if (k > 0) {
-      if (highIsGood) {
+      if (props.isResistance) {
         value -= 1 / k / 10;
         value = Math.ceil(value * k) / k;
-      } else {
-        value += 1 / k / 10;
+      } else if (props.roundDown) {
         value = Math.floor(value * k) / k;
+      } else {
+        value = Math.round(value * k) / k;
       }
     }
 

--- a/src/ShipStatistics/ShipStatistics.tsx
+++ b/src/ShipStatistics/ShipStatistics.tsx
@@ -101,7 +101,7 @@ export const ShipStatistics = () => {
         headerLabel="Defense"
         headerContent={
           <span>
-            <ShipAttribute name="ehp" fixed={0} /> ehp
+            <ShipAttribute name="ehp" fixed={0} roundDown /> ehp
           </span>
         }
       >
@@ -128,9 +128,9 @@ export const ShipStatistics = () => {
               <Icon name="shield-hp" size={24} />
             </span>
             <span>
-              <ShipAttribute name="shieldCapacity" fixed={0} /> hp
+              <ShipAttribute name="shieldCapacity" fixed={0} roundDown /> hp
               <br />
-              <ShipAttribute name="shieldRechargeRate" fixed={0} divideBy={1000} /> s<br />
+              <ShipAttribute name="shieldRechargeRate" fixed={0} divideBy={1000} roundDown /> s<br />
             </span>
           </span>
           <span style={{ flex: 2 }}>
@@ -146,7 +146,7 @@ export const ShipStatistics = () => {
               <Icon name="armor-hp" size={24} />
             </span>
             <span>
-              <ShipAttribute name="armorHP" fixed={0} /> hp
+              <ShipAttribute name="armorHP" fixed={0} roundDown /> hp
             </span>
           </span>
           <span style={{ flex: 2 }}>
@@ -162,7 +162,7 @@ export const ShipStatistics = () => {
               <Icon name="hull-hp" size={24} />
             </span>
             <span>
-              <ShipAttribute name="hp" fixed={0} /> hp
+              <ShipAttribute name="hp" fixed={0} roundDown /> hp
             </span>
           </span>
           <span style={{ flex: 2 }}>


### PR DESCRIPTION
- HP is always floor().
- Resistance is ceil(), sometimes. 10.01 becomes 10, but 10.1 becomes 11.
- Rest seems to be rounding.