### PR TITLE
chore: remove teardown of window functions

### DIFF
--- a/src/DogmaEngineProvider/DogmaEngineProvider.tsx
+++ b/src/DogmaEngineProvider/DogmaEngineProvider.tsx
@@ -86,14 +86,6 @@ export const DogmaEngineProvider = (props: DogmaEngineProps) => {
     window.get_type_id = (type_id: number): TypeID | undefined => {
       return eveData.typeIDs?.[type_id];
     };
-
-    return () => {
-      window.get_dogma_attributes = undefined;
-      window.get_dogma_attribute = undefined;
-      window.get_dogma_effects = undefined;
-      window.get_dogma_effect = undefined;
-      window.get_type_id = undefined;
-    };
   }, [eveData]);
 
   React.useEffect(() => {


### PR DESCRIPTION
React in StrictMode should run effect -> teardown -> effect, but for some reason it never does the second "effect" in time. In result, the dogma-engine is marked as loaded, but it really isn't.

Setting the dogma-engine as unloaded also doesn't work, as that signal arrives after the dogma-engine is used.