### PR TITLE
chore: rename "npm run prettier" to "npm run format"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ It will reload automatically on changes to the code.
 
 ### Linting and coding style
 
-Each Pull Request is validated by eslint and prettier.
+Each Pull Request is validated by `eslint` and `prettier`.
 To run this locally:
 
 ```bash
 npm run lint
-npm run prettier
+npm run format
 ```
 
 The last command will modify source files where needed.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "rollup -c",
     "build-storybook": "storybook build",
     "dev": "storybook dev -p 6006 --no-open",
-    "lint": "eslint .storybook src --ext .js,.ts,.tsx --cache && prettier -c .storybook src",
-    "prettier": "prettier -w .storybook src"
+    "format": "prettier -w .storybook src",
+    "lint": "eslint .storybook src --ext .js,.ts,.tsx --cache && prettier -c .storybook src"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You don't actually care what software does the formatting. Just that it gets done.