### PR TITLE
feat: ability to drag and drop items

### DIFF
--- a/src/components/HardwareListing/HardwareListing.tsx
+++ b/src/components/HardwareListing/HardwareListing.tsx
@@ -43,6 +43,24 @@ interface Filter {
 const ModuleGroup = (props: { level: number; group: ListingGroup; hideGroup?: boolean }) => {
   const shipSnapShot = React.useContext(ShipSnapshotContext);
 
+  const onItemDragStart = React.useCallback(
+    (
+      typeId: ListingItem["typeId"],
+      slotType: ListingItem["slotType"],
+    ): ((e: React.DragEvent<HTMLDivElement>) => void) => {
+      return (e: React.DragEvent<HTMLDivElement>) => {
+        // TODO: In case if image was not loaded/cached before, when user will drag a module for the first time
+        // image wont be visible. On every subsequent drag of the same module image will be visible because it was already cached.
+        let img = new Image();
+        img.src = `https://images.evetech.net/types/${typeId}/icon?size=64`;
+        e.dataTransfer.setDragImage(img, 32, 32);
+        e.dataTransfer.setData("application/type_id", typeId.toString());
+        e.dataTransfer.setData("application/slot_type", slotType);
+      };
+    },
+    [],
+  );
+
   const getChildren = React.useCallback(() => {
     return (
       <>
@@ -66,6 +84,7 @@ const ModuleGroup = (props: { level: number; group: ListingGroup; hideGroup?: bo
                   level={2}
                   content={item.name}
                   onClick={() => shipSnapShot.addModule(item.typeId, slotType)}
+                  onDragStart={onItemDragStart(item.typeId, slotType)}
                 />
               );
             }

--- a/src/components/HardwareListing/HardwareListing.tsx
+++ b/src/components/HardwareListing/HardwareListing.tsx
@@ -49,9 +49,7 @@ const ModuleGroup = (props: { level: number; group: ListingGroup; hideGroup?: bo
       slotType: ListingItem["slotType"],
     ): ((e: React.DragEvent<HTMLDivElement>) => void) => {
       return (e: React.DragEvent<HTMLDivElement>) => {
-        // TODO: In case if image was not loaded/cached before, when user will drag a module for the first time
-        // image wont be visible. On every subsequent drag of the same module image will be visible because it was already cached.
-        let img = new Image();
+        const img = new Image();
         img.src = `https://images.evetech.net/types/${typeId}/icon?size=64`;
         e.dataTransfer.setDragImage(img, 32, 32);
         e.dataTransfer.setData("application/type_id", typeId.toString());
@@ -100,7 +98,7 @@ const ModuleGroup = (props: { level: number; group: ListingGroup; hideGroup?: bo
           })}
       </>
     );
-  }, [props, shipSnapShot]);
+  }, [props, shipSnapShot, onItemDragStart]);
 
   if (props.hideGroup) {
     return <TreeListing level={props.level} getChildren={getChildren} />;

--- a/src/components/ShipFit/Slot.tsx
+++ b/src/components/ShipFit/Slot.tsx
@@ -151,7 +151,7 @@ export const Slot = (props: { type: string; index: number; fittable: boolean; ma
 
   const onDragStart = React.useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
-      if (!esiItem) return;
+      if (esiItem === undefined) return;
 
       e.dataTransfer.setData("application/type_id", esiItem.type_id.toString());
       e.dataTransfer.setData("application/slot_id", esiFlag.toString());
@@ -177,11 +177,10 @@ export const Slot = (props: { type: string; index: number; fittable: boolean; ma
       const draggedSlotId: number | undefined = parseNumber(e.dataTransfer.getData("application/slot_id"));
       const draggedSlotType: string = e.dataTransfer.getData("application/slot_type");
 
-      if (!draggedTypeId) {
+      if (draggedTypeId === undefined) {
         return;
       }
 
-      // TODO: Move validation into ShipSnapshotProvider
       const isValidSlotGroup = draggedSlotType === esiFlagType;
       if (!isValidSlotGroup) {
         return;
@@ -194,7 +193,7 @@ export const Slot = (props: { type: string; index: number; fittable: boolean; ma
         shipSnapshot.setModule(draggedTypeId, esiFlag);
       }
     },
-    [shipSnapshot, esiItem, esiFlag, esiFlagType],
+    [shipSnapshot, esiFlag, esiFlagType],
   );
 
   /* Not fittable and nothing fitted; no need to render the slot. */

--- a/src/components/TreeListing/TreeListing.tsx
+++ b/src/components/TreeListing/TreeListing.tsx
@@ -53,6 +53,7 @@ export const TreeLeaf = (props: {
   iconTitle?: string;
   content: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onDragStart?: (e: React.DragEvent<HTMLDivElement>) => void;
 }) => {
   const stylesHeader = styles[`header${props.level}`];
 
@@ -69,6 +70,8 @@ export const TreeLeaf = (props: {
             [styles.leaf]: props.onClick !== undefined,
           })}
           onClick={props.onClick}
+          draggable={!!props.onDragStart}
+          onDragStart={props.onDragStart}
         >
           {props.icon !== undefined && (
             <span className={styles.leafIcon}>

--- a/src/providers/ShipSnapshotProvider/ShipSnapshotProvider.tsx
+++ b/src/providers/ShipSnapshotProvider/ShipSnapshotProvider.tsx
@@ -210,7 +210,7 @@ export const ShipSnapshotProvider = (props: ShipSnapshotProps) => {
       fromItem.flag = toFlag;
 
       if (toItem !== undefined) {
-        /* Target slot is non-empty, swap items */
+        /* Target slot is non-empty, swap items. */
         toItem.flag = fromFlag;
       }
 


### PR DESCRIPTION
Fixes https://github.com/EVEShipFit/roadmap/issues/46

New Features: 
1. Added an ability to drag fitted items around: swap them or move an item to an empty slot. Added a special handling for fitted items with charges.

2. Added an ability to drag an item from Hardware to an individual fit slot. A support for dragging charges from the charges tab was not added in this pull-request.

Drag and drop feature is powered by a native [HTML Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API).

There is a problem with the drag item image in case if user drags an item from the Hardware list for the first time. HTML Drag and Drop API supports a way to set an image like this:

```js
 let img = new Image();
 img.src = `https://images.evetech.net/types/${typeId}/icon?size=64`;
 e.dataTransfer.setDragImage(img, 32, 32);
```

Evetech images are not preloaded, and in case if Browser doesn't have the image cached/preloaded even if an image is set like in the code snipped above it wont be displayed, but it will on every other attempt to drag the same item.
