### PR TITLE
fix: unbreak "fit:v1" links

### DIFF
--- a/src/hooks/ImportEveShipFitHash/DecodeEsfFitV1.tsx
+++ b/src/hooks/ImportEveShipFitHash/DecodeEsfFitV1.tsx
@@ -1,4 +1,4 @@
-import { EsfFit, EsfModule } from "@/providers/CurrentFitProvider";
+import { EsfCargo, EsfDrone, EsfFit, EsfModule } from "@/providers/CurrentFitProvider";
 
 import { decompress } from "./Decompress";
 import { esiFlagToEsfSlot } from "./EsiFlags";
@@ -9,21 +9,58 @@ export async function decodeEsfFitV1(fitCompressed: string): Promise<EsfFit | nu
   const fitLines = fitEncoded.trim().split("\n");
   const fitHeader = fitLines[0].split(",");
 
-  const modules = fitLines.slice(1).map((line): EsfModule => {
-    const item = line.split(",");
-    return {
-      slot: esiFlagToEsfSlot[parseInt(item[0])],
-      typeId: parseInt(item[1]),
-      state: "Active",
-    };
-  });
+  const modules = fitLines
+    .slice(1)
+    .map((line): EsfModule | undefined => {
+      const item = line.split(",");
+      const flag = parseInt(item[0]);
+      if (esiFlagToEsfSlot[flag] === undefined) return undefined; // Skip anything not modules.
+
+      return {
+        slot: esiFlagToEsfSlot[flag],
+        typeId: parseInt(item[1]),
+        state: "Active",
+      };
+    })
+    .filter((item): item is EsfModule => item !== undefined);
+
+  const drones = fitLines
+    .slice(1)
+    .map((line): EsfDrone | undefined => {
+      const item = line.split(",");
+      const flag = parseInt(item[0]);
+      if (flag != 87) return undefined; // Skip anything not drones.
+
+      return {
+        typeId: parseInt(item[1]),
+        states: {
+          Active: parseInt(item[2]),
+          Passive: 0,
+        },
+      };
+    })
+    .filter((item): item is EsfDrone => item !== undefined);
+
+  const cargo = fitLines
+    .slice(1)
+    .map((line): EsfCargo | undefined => {
+      const item = line.split(",");
+      const flag = parseInt(item[0]);
+      if (flag != 5) return undefined; // Skip anything not cargo.
+
+      return {
+        typeId: parseInt(item[1]),
+        quantity: parseInt(item[2]),
+      };
+    })
+    .filter((item): item is EsfCargo => item !== undefined);
 
   return {
     shipTypeId: parseInt(fitHeader[0]),
     name: fitHeader[1],
     description: fitHeader[2],
     modules,
-    drones: [], // v1 didn't store drones.
-    cargo: [], // v2 didn't store cargo.
+    drones,
+    cargo,
   };
 }


### PR DESCRIPTION
They did have drones and cargo stored, so process them correctly.

During the time `v1` was used, drones and cargo weren't dealt with. So I was under the assumption they also weren't stored in the hash.

I was wrong.

Luckily, `v1` never existed after making EVEShip.fit public, so there is little impact.