### PR TITLE
fix: error during build step with newer rollup

### DIFF
--- a/src/hooks/ExportEveShipFit/ExportEveShipFit.tsx
+++ b/src/hooks/ExportEveShipFit/ExportEveShipFit.tsx
@@ -12,7 +12,7 @@ async function compress(str: string): Promise<string> {
     const { done, value } = await reader.read();
     if (done) break;
 
-    result += String.fromCharCode.apply(null, value);
+    result += String.fromCharCode.apply(null, [...value]);
   }
 
   return btoa(result);


### PR DESCRIPTION
Uint8Array can no longer be cast to number[]. So do it manually.