### PR TITLE
fix: order of modules (high, med, low) in EFT export is flipped

### DIFF
--- a/src/hooks/ExportEft/ExportEft.tsx
+++ b/src/hooks/ExportEft/ExportEft.tsx
@@ -33,7 +33,7 @@ export function useExportEft() {
 
     eft += `[${shipType.name}, ${fit.name}]\n`;
 
-    for (const slotType of ["High", "Medium", "Low", "Rig", "SubSystem"] as EsfSlotType[]) {
+    for (const slotType of ["Low", "Medium", "High", "Rig", "SubSystem"] as EsfSlotType[]) {
       for (let i = 1; i <= statistics.slots[slotType]; i++) {
         const module = fit.modules.find((item) => item.slot.type === slotType && item.slot.index === i);
         if (module === undefined) {


### PR DESCRIPTION
Most tools (including in-game) export in the order: low, med, high. Not that it should really matter, as most tools can import both orders just fine. But still. Be more like others.